### PR TITLE
Support DbContext pooling

### DIFF
--- a/GenericEventRunner/ForDbContext/DbContextWithEvents.cs
+++ b/GenericEventRunner/ForDbContext/DbContextWithEvents.cs
@@ -29,6 +29,15 @@ namespace GenericEventRunner.ForDbContext
         /// </summary>
         public IStatusGeneric<int> StatusFromLastSaveChanges { get; private set; } 
 
+        /// <summary>
+        /// This sets up the DbContext options and adds the eventRunner
+        /// </summary>
+        /// <param name="options">normal EF Core options for a database</param>
+        /// <param name="eventsRunner">The Generic Event Runner - can be null which will turn off domain event handling</param>
+        protected DbContextWithEvents(DbContextOptions options, IEventsRunner eventsRunner) : base(options)
+        {
+            _eventsRunner = eventsRunner;
+        }
 
         /// <summary>
         /// This sets up the DbContext options and adds the eventRunner


### PR DESCRIPTION
Pooling wants a constructor with a non-generic options.
`""The DbContext of type 'CoreContext' cannot be pooled because it does not have a single public constructor accepting a single parameter of type DbContextOptions"`

**Update:** Sorry I thought this was a quick edit and done, but it seems like DbContext pooling potentially isn't a good mix with this library. [Source](https://stackoverflow.com/a/55917552/725626)